### PR TITLE
수정: 새로고침 시 계정 활성 여부 'N'인 사용자가 사라지지 않게끔 구현

### DIFF
--- a/backend/adminapp/views.py
+++ b/backend/adminapp/views.py
@@ -118,11 +118,12 @@ class AdminUsersView(APIView):
             }, status=status.HTTP_401_UNAUTHORIZED)
         
         # 데이터베이스에서 사용자 정보 조회하여 관리자 권한 확인
+        # WHERE 절에 use_yn='Y' 조건 제외: 비활성화된 사용자도 조회 가능해야 함
         try:
             with connection.cursor() as cursor:
                 cursor.execute("""
                     SELECT auth FROM user_info 
-                    WHERE user_id = %s AND use_yn = 'Y'
+                    WHERE user_id = %s 
                 """, [user_id])
                 
                 user_data = cursor.fetchone()
@@ -161,11 +162,12 @@ class AdminUsersView(APIView):
             page_size = int(request.GET.get('page_size', 10))
             
             # 기본 쿼리
+            # WHERE use_yn = 'Y' 조건 제외: 비활성화된 사용자도 조회 가능해야 함
             base_query = """
                 SELECT user_id, user_login_id, name, dept, rank, email, 
                        created_dt, use_yn, auth
                 FROM user_info 
-                WHERE use_yn = 'Y'
+                WHERE 1=1
             """
             params = []
             

--- a/frontend/src/pages/Admin/MembersPage.jsx
+++ b/frontend/src/pages/Admin/MembersPage.jsx
@@ -175,6 +175,8 @@ function MembersPage() {
    const handleSearch = () => {
     console.log(`검색 유형: ${searchType}, 검색어: ${searchTerm}`);
    
+
+
     // 검색 필터 구성
     let filter = "";
     if (searchTerm.trim()) {


### PR DESCRIPTION
# PR 타이틀
수정: 새로고침 시 계정 활성 여부 'N'인 사용자가 사라지지 않게끔 구현


## PR생성날짜
2025/09/02

## PR 내용
- views.py 수정
- 기존: 쿼리에 `WHERE use_yn = 'Y'` 조건으로 인해 화면에 계정 활성 여부가 'Y'인 사용자만 출력됨.  
- 수정: 쿼리에 `WHERE use_yn = 'Y'` 조건을 제거함. 새로고침 시 계정 활성 여부 'N'인 사용자가 사라지지 않게끔 구현함.



