### PR TITLE
수정: 채팅 페이지 새로고침 시 화면 초기화 방지

### DIFF
--- a/frontend/src/pages/Chat/Sidebar.jsx
+++ b/frontend/src/pages/Chat/Sidebar.jsx
@@ -129,7 +129,10 @@ function Sidebar({
         {/* 상단 로고 */}
         <div
           className="flex items-center justify-center h-16 border-b border-gray-700 cursor-pointer"
-          onClick={() => window.location.reload()}
+          onClick={() => {
+            sessionStorage.clear();
+            window.location.reload();    
+          }}
         >
           {/* <h1 className="text-xl font-bold">NAVI</h1> */}
           <img src="/images/logo3.png" alt="NAVI Logo" className="h-28 mr-3" />


### PR DESCRIPTION
# PR 타이틀
수정: 채팅 페이지 새로고침 시 화면 초기화 방지

## PR생성날짜
2025/09/03


## PR 내용
채팅 페이지(/chat)에서 새로고침 관련하여 수정했습니다. 내용은 아래와 같습니다. 

채팅 페이지 새로고침 시 기존에 선택한 채팅 또는 영수증 출력이 초기화 되지 않게 구현함. 세션 스토리지에 선택 정보를 저장해 새로고침 시 불러오도록 함.

1. 사이드바에서 카테고리 선택 후 새로고침 시, 카테고리가 업무 가이드로 초기화 되지 않고 선택된 것을 유지.
2. 업무 가이드: 기존 대화 내역 선택 후 새로고침 시 기존 대화 내역 출력이 사라지지 않게 수정. (수정 전: 기존 대화 내역 출력이 사라지고 화면 초기화)
3. 업무 가이드: 새 채팅 생성 버튼 클릭 후 새로고침 시 새 채팅이 목록에서 사라지게 함. 새 채팅이 중복해서 생기는 것을 방지함. 
4. 영수증 처리: 기존 영수증 내역 선택 후 새로고침 시 기존 영수증 내역 출력이 사라지지 않게 수정. (수정 전: 기존 영수증 내역 출력이 사라지고 화면 초기화)
5. 영수증 처리: 새 영수증 생성 버튼 클릭 후 새로고침 시 새 영수증이 목록에서 사라지게 함. 새 영수증이 중복해서 생기는 것을 방지함.
6. 관리자 페이지나 마이페이지, 로그아웃과 같이 다른 페이지로 이동 후 다시 채팅 페이지로 올 경우, 세션 스토리지에 저장된 선택 정보가 초기화됨. 기존에 선택한 채팅 또는 영수증이 다른 페이지로 갔다 왔을 때 그대로 유지하지 않고 초기화 되게 함.
7. 사이드바 상단에 나비 로고 클릭 시 세션 스토리지에 저장된 선택 정보가 사라지고 화면이 초기화 됨.  


