### PR TITLE
수정: 모든 페이지 사이드바 통일, 관리자 페이지 디자인 디테일 수정

### DIFF
--- a/frontend/src/pages/Admin/ChatReportsPage.jsx
+++ b/frontend/src/pages/Admin/ChatReportsPage.jsx
@@ -339,33 +339,38 @@ function ChatReportsPage() {
 
   return (
     <div className="flex h-screen">
-      <div className="w-64 bg-gray-800 text-white flex-shrink-0 h-screen">
-      <AdminSidebar 
+      <div className="w-72 bg-gray-800 text-white flex-shrink-0 h-screen">
+      <AdminSidebar
         userName={userName}
         selectedTab={selectedTab}
         onTabSelect={handleTabSelect}
         onChatPageClick={handleChatPageClick}
       />
       </div>
-      <div className="flex-1 overflow-y-auto p-6">
-        <h1 className="text-2xl font-bold mb-4">대화 신고 내역</h1>
-        <DateSelectBar 
-          startDate={startDate}
-          endDate={endDate}
-          onDateChange={handleDateChange}
-          onClearDateFilter={handleClearDateFilter}
-        />
-        <SearchBar
-          searchTerm={searchTerm}
-          setSearchTerm={setSearchTerm}
-          onSearch={handleSearch}
-          searchType={searchType}
-          setSearchType={setSearchType}
-          searchOptions={searchOptions}
-          onClearSearch={handleClearSearch}
-          errorTypeOptions={errorTypeOptions}
-        />
+      <div className="flex-1 overflow-y-auto p-6 bg-white">
+        <h1 className="text-2xl font-bold mb-6">대화 신고 내역</h1>
+        <div className="mb-2">
+          <DateSelectBar 
+            startDate={startDate}
+            endDate={endDate}
+            onDateChange={handleDateChange}
+            onClearDateFilter={handleClearDateFilter}
+          />
+        </div>
         
+        <div className="mb-2">
+          <SearchBar
+            searchTerm={searchTerm}
+            setSearchTerm={setSearchTerm}
+            onSearch={handleSearch}
+            searchType={searchType}
+            setSearchType={setSearchType}
+            searchOptions={searchOptions}
+            onClearSearch={handleClearSearch}
+            errorTypeOptions={errorTypeOptions}
+          />
+        </div>
+      
         {isLoading && (
           <div className="text-center py-8">
             <p className="text-gray-500">데이터를 불러오는 중...</p>

--- a/frontend/src/pages/Admin/ManageReceipts.jsx
+++ b/frontend/src/pages/Admin/ManageReceipts.jsx
@@ -60,7 +60,7 @@ function ManageReceipts() {
           // 데이터를 미리 로드
           const params = new URLSearchParams();
           params.append("page", "1");
-          params.append("page_size", "10");
+          params.append("page_size", "7");
           
           if (startDate) {
             params.append("start_date", startDate);
@@ -130,7 +130,7 @@ function ManageReceipts() {
       
       const params = new URLSearchParams();
       params.append('page', page.toString());
-      params.append('page_size', '10');
+      params.append('page_size', '7');
       
       if (startDate) {
         params.append('start_date', startDate);
@@ -487,7 +487,7 @@ function ManageReceipts() {
 
   return (
     <div className="flex h-screen">
-      <div className="w-64 bg-gray-800 text-white flex-shrink-0 h-screen">
+      <div className="w-72 bg-gray-800 text-white flex-shrink-0 h-screen">
         <AdminSidebar 
         userName={userName}
         onUserNameClick={handleUserNameClick}
@@ -497,7 +497,7 @@ function ManageReceipts() {
         onChatPageClick={handleChatPageClick}
       />
       </div>
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-6 bg-white">
         <h1 className="text-2xl font-bold mb-6">영수증 관리</h1>
         
         {/* 에러 메시지 */}
@@ -508,7 +508,7 @@ function ManageReceipts() {
         )}
         
         {/* 기간 선택 바 */}
-        <div className="mb-6">
+        <div className="mb-2">
           <DateSelectBar 
             onDateChange={handleDateChange}
             startDate={startDate}
@@ -518,42 +518,44 @@ function ManageReceipts() {
         </div>
         
         {/* 검색 바 */}
-        <div className="mb-6">
-          <SearchBar
-            searchTerm={searchTerm}
-            setSearchTerm={setSearchTerm}
-            onSearch={handleSearch}
-            searchType={searchType}
-            setSearchType={setSearchType}
-            searchOptions={searchOptions}
-            onClearSearch={handleClearSearch}
-          />
-        </div>
-        
-        {/* 엑셀 다운로드 버튼 */}
-        <div className="flex justify-between items-center mb-4">
-          {/* 날짜 필터 정보 및 초기화 버튼 */}
-          {(startDate || endDate) && (
-            <div className="flex items-center space-x-3">
-              <span className="text-sm text-gray-600">
-                기간: {startDate ? new Date(startDate).toLocaleDateString('ko-KR') : '시작일'} ~ {endDate ? new Date(endDate).toLocaleDateString('ko-KR') : '종료일'}
-              </span>
-              <button
-                onClick={handleClearDateFilter}
-                className="text-xs text-red-600 hover:text-red-800 underline"
-              >
-                날짜 필터 초기화
-              </button>
-            </div>
-          )}
-          
+        <div className="flex items-center justify-between mb-2 gap-2">
+          <div>
+            <SearchBar
+              searchTerm={searchTerm}
+              setSearchTerm={setSearchTerm}
+              onSearch={handleSearch}
+              searchType={searchType}
+              setSearchType={setSearchType}
+              searchOptions={searchOptions}
+              onClearSearch={handleClearSearch}
+            />
+          </div>
           <button
             onClick={handleExcelDownload}
-            className="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded shadow transition-colors"
+            className="h-10 flex items-center bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded shadow transition-colors"
           >
             엑셀 다운로드
           </button>
         </div>
+        
+          <div className="flex items-center space-x-3">
+            {/* 날짜 필터 정보 및 초기화 버튼 */}
+            {(startDate || endDate) && (
+              <>
+                <span className="text-sm text-gray-600">
+                  기간: {startDate ? new Date(startDate).toLocaleDateString('ko-KR') : '시작일'} ~ {endDate ? new Date(endDate).toLocaleDateString('ko-KR') : '종료일'}
+                </span>
+                <button
+                  onClick={handleClearDateFilter}
+                  className="text-xs text-red-600 hover:text-red-800 underline"
+                >
+                  날짜 필터 초기화
+                </button>
+              </>
+            )}
+          </div>
+
+       
 
         {/* 로딩 상태 */}
         {isLoading ? (
@@ -565,7 +567,6 @@ function ManageReceipts() {
             {/* 검색 결과 요약 */}
             {!error && receipts.length > 0 && (
               <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg">
-                <div className="flex justify-between items-center">
                   <p className="text-sm text-green-800">
                     총 <span className="font-medium">{totalCount}</span>건의 영수증을 찾았습니다.
                     {(startDate || endDate) && (
@@ -574,9 +575,9 @@ function ManageReceipts() {
                       </span>
                     )}
                   </p>
-                </div>
               </div>
             )}
+         
             
             {/* 데이터 테이블 */}
             <div className="mb-6">

--- a/frontend/src/pages/Admin/MembersPage.jsx
+++ b/frontend/src/pages/Admin/MembersPage.jsx
@@ -228,7 +228,7 @@ function MembersPage() {
 
   return (
     <div className="flex h-screen">
-      <div className="w-64 bg-gray-800 text-white flex-shrink-0 h-screen">
+      <div className="w-72 bg-gray-800 text-white flex-shrink-0 h-screen">
         <AdminSidebar 
         userName={userName}
         selectedTab={selectedTab}

--- a/frontend/src/pages/Admin/components/AdminSidebar.jsx
+++ b/frontend/src/pages/Admin/components/AdminSidebar.jsx
@@ -1,103 +1,111 @@
-import React from "react";
+
 import { useNavigate } from "react-router-dom";
 import { authService } from "../../../services/authService";
 
 
-function AdminSidebar({ userName, selectedTab, onTabSelect, onChatPageClick }) {
+function AdminSidebar1({
+  userName,
+  selectedTab, 
+  onTabSelect,
+  onChatPageClick,
+}) {
   const navigate = useNavigate();
   const initials = userName?.[0] || "A";
   const displayName = userName || "관리자";
 
   // 마이페이지 이동 핸들러
-  const handleUserNameClick = () => {
-    navigate("/mypage");
-  };
-
-  // 로그아웃 핸들러
-  const handleLogout = async () => {
-    try {
-      // 백엔드에 로그아웃 요청 (토큰 무효화)
-      const response = await authService.logout();
-
-      // 백엔드 응답 확인
-      if (response && response.success) {
-        console.log("백엔드 로그아웃 성공:", response.message);
+    const handleUserNameClick = () => {
+      navigate("/chat");
+    };
+  
+    // 로그아웃 핸들러
+    const handleLogout = async () => {
+      try {
+        // 백엔드에 로그아웃 요청 (토큰 무효화)
+        const response = await authService.logout();
+  
+        // 백엔드 응답 확인
+        if (response && response.success) {
+          console.log("백엔드 로그아웃 성공:", response.message);
+        }
+      } catch (error) {
+        console.error("백엔드 로그아웃 실패:", error);
+        // 백엔드 실패해도 계속 진행
+      } finally {
+        // 성공/실패와 관계없이 로컬 로그아웃 처리
+        localStorage.clear();
+  
+        // 명시적으로 루트 페이지로만 이동 (로그인 화면)
+        console.log("로그아웃 완료, 루트 페이지(/)로 이동");
+        window.location.href = "/"; // 강제로 루트 페이지로 이동
       }
-    } catch (error) {
-      console.error("백엔드 로그아웃 실패:", error);
-      // 백엔드 실패해도 계속 진행
-    } finally {
-      // 성공/실패와 관계없이 로컬 로그아웃 처리
-      localStorage.clear();
-
-      // 명시적으로 루트 페이지로만 이동 (로그인 화면)
-      console.log("로그아웃 완료, 루트 페이지(/)로 이동");
-      window.location.href = "/"; // 강제로 루트 페이지로 이동
-    }
-  };
-
-  // 현재 선택된 탭에 따른 스타일 클래스 반환
-  const getTabClass = (tabName) => {
-    return selectedTab === tabName
-      ? "bg-gray-700 text-white"
-      : "text-gray-300 hover:bg-gray-700 hover:text-white";
-  };
+    };
+  
+    // 현재 선택된 탭에 따른 스타일 클래스 반환
+    const getTabClass = (tabName) => {
+      return selectedTab === tabName
+        ? "bg-gray-700 text-white"
+        : "text-gray-300 hover:bg-gray-700 hover:text-white";
+    };
 
   return (
-    <div className="flex flex-col w-64 bg-gray-800 text-white min-h-screen">
-      {/* 상단 관리자 메뉴 */}
-      <div className="p-4">
-        <h2 className="text-xl font-bold mb-6">관리자 메뉴</h2>
-        <div className="space-y-4">
+    <>
+      <div className="flex flex-col w-72 h-screen bg-gray-800 text-white">
+        {/* 상단 로고 */}
+        <div
+          className="flex items-center justify-center h-16 border-b border-gray-700 cursor-pointer"
+          onClick={() => {
+            sessionStorage.clear();
+            window.location.reload();    
+          }}
+        >
+          {/* <h1 className="text-xl font-bold">NAVI</h1> */}
+          <img src="/images/logo3.png" alt="NAVI Logo" className="h-28 mr-3" />
+        </div>
+
+        {/* 카테고리 메뉴 */}
+        <div className="flex flex-col px-2 py-4 gap-2">
           <div
-            className={`flex items-center px-4 py-2 rounded-md cursor-pointer transition ${getTabClass("members")}`}
+            className={`flex items-center px-4 py-2 rounded-md cursor-pointer ${getTabClass(
+              "회원 관리"
+            )}`}
             onClick={() => onTabSelect("members")}
           >
             회원 관리
           </div>
           <div
-            className={`flex items-center px-4 py-2 rounded-md cursor-pointer transition ${getTabClass("chat-reports")}`}
+            className={`flex items-center px-4 py-2 rounded-md cursor-pointer ${getTabClass(
+              "채팅 신고 내역"
+            )}`}
             onClick={() => onTabSelect("chat-reports")}
           >
             채팅 신고 내역
           </div>
           <div
-            className={`flex items-center px-4 py-2 rounded-md cursor-pointer transition ${getTabClass("manage-receipt")}`}
+            className={`flex items-center px-4 py-2 rounded-md cursor-pointer ${getTabClass(
+              "영수증 관리"
+            )}`}
             onClick={() => onTabSelect("manage-receipt")}
           >
             영수증 관리
           </div>
         </div>
-      </div>
-
-      {/* 하단 사용자명 + 로그아웃 */}
-      <div className="mt-auto">
-        {/* 채팅 화면으로 이동 버튼 - 사용자 프로필 바로 위 */}
-        <div className="px-4 py-2 border-t border-gray-700">
-          <button
-            type="button"
-            onClick={onChatPageClick}
-            className="w-full py-2 px-4 rounded-md bg-green-600 hover:bg-green-700 text-white text-center font-medium transition flex items-center justify-center gap-2"
-            title="채팅 화면으로 이동"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+          
+        {/* 하단 사용자명 + 로그아웃 */}
+        <div className="mt-auto px-4 py-3 border-t border-gray-700">
+          <div className="mb-2">
+            <button
+              type="button"
+              onClick={onChatPageClick}
+              className="w-full py-1 px-4 text-white text-center font-medium underline hover:text-gray-400 transition"
+              title="채팅 페이지로 이동"
             >
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-            </svg>
-            채팅 화면
-          </button>
-        </div>
+              채팅 페이지
+            </button>
+          </div>
 
-        {/* 사용자 프로필 섹션 */}
-        <div className="px-4 py-3 border-t border-gray-700">
+          <div className="border-t border-gray-700 my-3"></div>
+
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4 min-w-0">
               <div className="flex items-center justify-center h-8 w-8 rounded-full bg-gray-700 text-sm font-semibold">
@@ -107,7 +115,7 @@ function AdminSidebar({ userName, selectedTab, onTabSelect, onChatPageClick }) {
                 <button
                   type="button"
                   onClick={handleUserNameClick}
-                  className="text-m font-bold truncate hover:text-blue-300 transition cursor-pointer"
+                  className="text-m font-bold truncate hover:text-gray-400 transition cursor-pointer"
                   title="마이페이지로 이동"
                 >
                   {displayName}
@@ -115,7 +123,7 @@ function AdminSidebar({ userName, selectedTab, onTabSelect, onChatPageClick }) {
               </div>
             </div>
 
-            {/* 로그아웃 버튼 */}
+            {/* 로그아웃 버튼 (inline SVG 아이콘) */}
             <button
               type="button"
               onClick={handleLogout}
@@ -142,8 +150,8 @@ function AdminSidebar({ userName, selectedTab, onTabSelect, onChatPageClick }) {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 
-export default AdminSidebar;
+export default AdminSidebar1;

--- a/frontend/src/pages/Admin/components/Pagination.jsx
+++ b/frontend/src/pages/Admin/components/Pagination.jsx
@@ -1,32 +1,46 @@
 import React from "react";
 
 function Pagination({ currentPage, totalPages, onPageChange }) {
+  // 한 번에 보여줄 페이지 버튼 개수
+  const PAGE_GROUP_SIZE = 5;
+
+  // 현재 그룹의 첫 페이지 번호 계산
+  const groupStart = Math.floor((currentPage - 1) / PAGE_GROUP_SIZE) * PAGE_GROUP_SIZE + 1;
+  // 현재 그룹의 마지막 페이지 번호 계산
+  const groupEnd = Math.min(groupStart + PAGE_GROUP_SIZE - 1, totalPages);
+
+  const pageNumbers = [];
+  for (let i = groupStart; i <= groupEnd; i++) {
+    pageNumbers.push(i);
+  }
+
   return (
-    <div className="flex justify-center space-x-2 mt-4">
+    <div className="flex justify-center items-center gap-2 mt-6">
+      {/* 이전 그룹으로 이동 */}
       <button
-        onClick={() => onPageChange(currentPage - 1)}
-        disabled={currentPage === 1}
-        className="px-3 py-1 border rounded disabled:opacity-50"
+        disabled={groupStart === 1}
+        onClick={() => onPageChange(groupStart - 1)}
+        className="px-2 py-1 rounded bg-gray-100 text-gray-700 hover:bg-gray-300"
       >
-        이전
+        &lt;
       </button>
-      {[...Array(totalPages)].map((_, i) => (
+      {/* 페이지 번호 버튼 */}
+      {pageNumbers.map((page) => (
         <button
-          key={i}
-          onClick={() => onPageChange(i + 1)}
-          className={`px-3 py-1 border rounded ${
-            currentPage === i + 1 ? "bg-blue-500 text-white" : ""
-          }`}
+          key={page}
+          onClick={() => onPageChange(page)}
+          className={`px-3 py-1 rounded ${page === currentPage ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-300"}`}
         >
-          {i + 1}
+          {page}
         </button>
       ))}
+      {/* 다음 그룹으로 이동 */}
       <button
-        onClick={() => onPageChange(currentPage + 1)}
-        disabled={currentPage === totalPages}
-        className="px-3 py-1 border rounded disabled:opacity-50"
+        disabled={groupEnd === totalPages}
+        onClick={() => onPageChange(groupEnd + 1)}
+        className="px-2 py-1 rounded bg-gray-100 text-gray-700 hover:bg-gray-300"
       >
-        다음
+        &gt;
       </button>
     </div>
   );

--- a/frontend/src/pages/Chat/Sidebar.jsx
+++ b/frontend/src/pages/Chat/Sidebar.jsx
@@ -309,7 +309,7 @@ function Sidebar({
                 <button
                   type="button"
                   onClick={onUserNameClick}
-                  className="text-m font-bold truncate hover:text-gray-400 transition cursor-pointer"
+                  className="text-base font-bold truncate hover:text-gray-400 transition cursor-pointer"
                   title="마이페이지로 이동"
                 >
                   {displayName}


### PR DESCRIPTION
# PR 타이틀
수정: 모든 페이지 사이드바 통일, 관리자 페이지 디자인 디테일 수정


## PR생성날짜
2025/09/04


## PR 내용
<img width="1919" height="870" alt="스크린샷 2025-09-04 154946" src="https://github.com/user-attachments/assets/484201a7-1e5d-4b4b-87ee-06d0de5e72be" />

1. 모든 페이지 사이드바 통일
2. 관리자 - 영수증 관리 페이지 수정
    - 엑셀 다운로드 버튼 우측으로 이동
    - 표에 보이는 영수증 개수 최대 10개에서 8개로 줄임. 



