### PR TITLE
채팅 페이지 수정: 새 채팅 삭제 시 프론트에 정상 반영, 새 채팅 비활성화 문제 해결

### DIFF
--- a/frontend/src/pages/Chat/ChatPage.jsx
+++ b/frontend/src/pages/Chat/ChatPage.jsx
@@ -115,14 +115,6 @@ function ChatPage() {
         setChats(chatsWithMessageFlags);
         setReceipts(receiptsData);
 
-        // if (selectedCategory === "업무 가이드" && chatsData.length > 0) {
-        //   setSelectedChatId(chatsData[0].id);
-        // } else if (
-        //   selectedCategory === "영수증 처리" &&
-        //   receiptsData.length > 0
-        // ) {
-        //   setSelectedReceiptId(receiptsData[0].receipt_id);
-        // }
       } catch (error) {
         console.error("데이터 로드 실패:", error);
         // 실패해도 UI는 동작 가능하게 빈 배열 유지
@@ -142,14 +134,14 @@ function ChatPage() {
     sessionStorage.removeItem("selectedChatId");
     sessionStorage.removeItem("selectedReceiptId");
 
-    // 이미 새 채팅이 있으면 그걸 선택
-    const existingNewChat = chats.find((c) => c.isNew);
-    if (existingNewChat) {
-      setSelectedChatId(existingNewChat.id);
-      setSelectedCategory("업무 가이드");
-      setLockedChatId(existingNewChat.id);
-      return;
-    }
+    // // 이미 새 채팅이 있으면 그걸 선택
+    // const existingNewChat = chats.find((c) => c.isNew);
+    // if (existingNewChat) {
+    //   setSelectedChatId(existingNewChat.id);
+    //   setSelectedCategory("업무 가이드");
+    //   setLockedChatId(existingNewChat.id);
+    //   return;
+    // }
 
     // 프론트에서 임의 id로 새 채팅 생성
     const newChat = {
@@ -163,6 +155,7 @@ function ChatPage() {
     setSelectedChatId(newChat.id);
     setSelectedCategory("업무 가이드");
     setLockedChatId(newChat.id);
+    sessionStorage.setItem("selectedChatId", newChat.id);
   }, [chats]);
 
   // 새 영수증 생성 핸들러
@@ -190,6 +183,7 @@ function ChatPage() {
     setSelectedReceiptId(newReceipt.id);
     setSelectedCategory("영수증 처리");
     setReceiptDetails(null);
+    sessionStorage.setItem("selectedReceiptId", newReceipt.id);
   }, [receipts]);
 
   const handleReceiptSaveSuccess = useCallback(async () => {
@@ -346,6 +340,7 @@ function ChatPage() {
           );
           setSelectedChatId(newChatFromDB.id);
           setLockedChatId(newChatFromDB.id);
+          sessionStorage.setItem("selectedChatId", newChatFromDB.id);
 
           chatIdToUse = newChatFromDB.id;
         }
@@ -466,6 +461,7 @@ function ChatPage() {
         );
       } finally {
         setIsLoading(false);
+        setLockedChatId(null);
       }
     },
     [selectedChat, isLoading, lockedChatId]
@@ -510,6 +506,7 @@ function ChatPage() {
       setSelectedReceiptId(null);
       sessionStorage.removeItem("selectedReceiptId");
       sessionStorage.removeItem("selectedChatId");
+      setLockedChatId(null);
     }
   }, []);
 

--- a/frontend/src/pages/Chat/Sidebar.jsx
+++ b/frontend/src/pages/Chat/Sidebar.jsx
@@ -90,6 +90,11 @@ function Sidebar({
       // 삭제 중 상태로 설정
       setIsDeleting(true);
 
+      // 새 채팅방 생성 후 아무 메시지도 입력하지 않아 DB에 저장되지 않은 경우 프론트에서만 제거
+      if (chatId.startsWith("new-")) {
+        onDeleteChat(chatId);
+        return;
+      }
       // API 호출하여 채팅 삭제
       const response = await api.delete(`/chat/${chatId}/delete/`);
 


### PR DESCRIPTION
# PR 타이틀
채팅 페이지 수정: 새 채팅 삭제 시 프론트에 정상 반영, 새 채팅 비활성화 문제 해결


## PR생성날짜
2025/09/10


## PR 내용
### 1. 새 채팅방 생성 후 아무 메시지도 입력하지 않아 DB에 저장되지 않은 경우 프론트에서만 제거한다.
문제: 새 채팅 생성 후 아무 메시지를 보내지 않고 삭제 버튼을 누르면 이미 삭제되었다는 오류가 뜨고, 사이드바에서 새 채팅이 사라지지 않았다.

수정: 임시 Id, 즉 'new-'로 시작되는 채팅 Id는 api 호출 없이 OnDeleteChat에 chatId를 전달하게끔 해서 api 오류 없이 프론트에서 삭제를 반영하게 된다. 

수정 이후 채팅 삭제에서 오류가 없음을 확인했다. 
영수증의 경우 삭제 기능이 없기 때문에 괜찮다. 

또한 이 수정 이후 새 채팅방을 생성 후 삭제했을 때 다시 새 채팅방이 활성화됨을 확인했다. 

### 2. 새 채팅방 버튼을 적절히 활성화한다.
문제 1: 채팅 페이지에서 새 채팅 생성 후 영수증 페이지에 갔다가 오면 새 채팅이 사이드바에서 사라지며 새 채팅 버튼이 비활성화 되었다. 새로고침이나 다른 페이지에 갔다 오지 않으면 계속 비활성화 되었다.

수정: 영수증 처리로 전환할 때 setLockedChatId(null);을 적용해 영수증 처리 화면에 가면 채팅 disable이 풀리게 하였다.

업무 가이드 카테고리를 선택할 때 setLockedChatId(null);을 하는 경우 사이드바에서 업무 가이드 카테고리를 선택하기만 해도 disable이 풀리므로 영수증 처리 카테고리를 선택할 때 코드를 적용했다. 

문제 2: 새 채팅방을 생성하고 메시지를 보낸 경우에도 새 채팅방 버튼이 비활성화 되었다.
원래는 새 채팅방을 생성하고 메시지를 보낼 경우 DB에 저장이 되므로 새 채팅이 활성화 되어야 한다.

수정: 임시 채팅 여부와 관계 없이 메시지를 다 보내면 null로 바뀌게끔 하였다. 따라서 임시 채팅을 생성해 메시지를 보내도 setLockedChatId(null); 이 적용되어 새 채팅 버튼이 활성화 된다. 


